### PR TITLE
Update process-collect.nf

### DIFF
--- a/process-collect.nf
+++ b/process-collect.nf
@@ -42,7 +42,7 @@ process foo {
 process bar {
   echo true   
   input:
-  file '*.fq' from unzipped_ch.collect()
+  file '?.fq' from unzipped_ch.collect()
   """
   cat *.fq | head -n 50
   """


### PR DESCRIPTION
Fixes cases with a single file. Note that this example with `cat` would still work with a single file, but `ls *.fq` would not. https://github.com/nextflow-io/nextflow/issues/2410